### PR TITLE
adds lib files for publishing process

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "browser": {
     "lodash.custom": "./vendor/lodash.custom.min.js"
   },
+  "directories": {
+    "lib": "./lib"
+  },
   "browserify": {
     "transform": [
 	  "coffeeify"


### PR DESCRIPTION
This should add the lib files when you publish a package. Maybe worth testing it before merging. Unfortunately I can't really test it but I checked other projects how they do it and this should be the correct way.