### PR TITLE
Add triggers for variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 npm-debug.log
 node_modules/*
 lib
+.source*

--- a/src/alephbet.coffee
+++ b/src/alephbet.coffee
@@ -67,9 +67,16 @@ class AlephBet
       @storage().get("#{@options.name}:variant")
 
     pick_variant: ->
+      all_variants_have_triggers = utils.check_triggers(@variants)
       all_variants_have_weights = utils.check_weights(@variants)
       utils.log("all variants have weights: #{all_variants_have_weights}")
-      if all_variants_have_weights then @pick_weighted_variant() else @pick_unweighted_variant()
+      if all_variants_have_weights then @pick_weighted_variant() 
+      else if all_variants_have_triggers then @pick_triggered_variant()
+      else @pick_unweighted_variant()
+
+    pick_triggered_variant: ->
+      for key, value of @variants
+        return key if value.trigger()
 
     pick_weighted_variant: ->
 
@@ -125,6 +132,8 @@ class AlephBet
       throw new Error('trigger must be a function') if typeof @options.trigger isnt 'function'
       all_variants_have_weights = utils.validate_weights @options.variants
       throw new Error('not all variants have weights') if !all_variants_have_weights
+      all_variants_have_triggers = utils.validate_triggers @options.variants
+      throw new Error('not all variants have triggers') if !all_variants_have_triggers
 
   class @Goal
     constructor: (@name, @props={}) ->

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -22,6 +22,10 @@ class Utils
     contains_weight = []
     contains_weight.push(value.weight?) for key, value of variants
     contains_weight.every (has_weight) -> has_weight
+  @check_triggers: (variants) ->
+    contains_trigger = []
+    contains_trigger.push(value.trigger?) for key, value of variants
+    contains_trigger.every (has_trigger) -> has_trigger
   @sum_weights: (variants) ->
     sum = 0
     for key, value of variants
@@ -31,4 +35,8 @@ class Utils
     contains_weight = []
     contains_weight.push(value.weight?) for key, value of variants
     contains_weight.every (has_weight) -> has_weight or contains_weight.every (has_weight) -> !has_weight
+  @validate_triggers: (variants) ->
+    contains_trigger = []
+    contains_trigger.push(value.trigger?) for key, value of variants
+    contains_trigger.every (has_trigger) -> has_trigger or contains_trigger.every (has_trigger) -> !has_trigger
 module.exports = Utils

--- a/test/alephbet_test.coffee
+++ b/test/alephbet_test.coffee
@@ -132,21 +132,6 @@ describe 'when all variants have weights', (t) ->
   t.assert(ex.pick_variant() == 'green', 'always picks green variant')
   t.assert(ex.pick_variant() != 'blue', 'never picks blue variant')
 
-describe 'when all variants have triggers', (t) ->
-  ex = experiment({
-    name: 'with-triggers'
-    variants:
-      blue:
-        trigger: -> false
-        activate: activate
-      green:
-        trigger: -> true
-        activate: activate
-  })
-  t.plan(2)
-  t.assert(ex.pick_variant() == 'green', 'always picks green variant')
-  t.assert(ex.pick_variant() != 'blue', 'never picks blue variant')
-
 describe 'when all variants have weights (with user_id)', (t) ->
   ex = experiment({
     user_id: 'yuzu'
@@ -163,23 +148,6 @@ describe 'when all variants have weights (with user_id)', (t) ->
   ex.user_id = 'gosho'
   t.assert(ex.pick_variant() == 'red', 'always picks red variant')
 
-describe 'when all variants have triggers (with user_id)', (t) ->
-  changed = { test: true }
-  ex = experiment({
-    user_id: 'yuzu'
-    variants:
-      blue:
-        trigger: -> changed.test
-        activate: activate
-      red:
-        trigger: -> !changed.test
-        activate: activate
-  })
-  t.plan(2)
-  t.assert(ex.pick_variant() == 'blue', 'always picks blue variant')
-  changed.test = false
-  t.assert(ex.pick_variant() == 'red', 'always picks red variant')
-
 describe 'when only some variants have weights', (t) ->
   try ex = experiment({
     name: 'not-all-weights'
@@ -193,3 +161,35 @@ describe 'when only some variants have weights', (t) ->
   catch e then t.assert(true, 'creating experiment should throw error')
   t.plan(2)
   t.assert(activate.callCount == 0, "activate function shouldn't be called")
+
+
+describe 'when all variants have triggers', (t) ->
+  ex = experiment({
+    name: 'with-triggers'
+    variants:
+      blue:
+        trigger: -> false
+        activate: activate
+      green:
+        trigger: -> true
+        activate: activate
+  })
+  t.plan(2)
+  t.assert(ex.pick_variant() == 'green', 'always picks green variant')
+  t.assert(ex.pick_variant() != 'blue', 'never picks blue variant')
+
+describe 'when all variants have triggers (changing variant)', (t) ->
+  changed = { test: true }
+  ex = experiment({
+    variants:
+      blue:
+        trigger: -> changed.test
+        activate: activate
+      red:
+        trigger: -> !changed.test
+        activate: activate
+  })
+  t.plan(2)
+  t.assert(ex.pick_variant() == 'blue', 'always picks blue variant')
+  changed.test = false
+  t.assert(ex.pick_variant() == 'red', 'always picks red variant')

--- a/test/alephbet_test.coffee
+++ b/test/alephbet_test.coffee
@@ -132,6 +132,21 @@ describe 'when all variants have weights', (t) ->
   t.assert(ex.pick_variant() == 'green', 'always picks green variant')
   t.assert(ex.pick_variant() != 'blue', 'never picks blue variant')
 
+describe 'when all variants have triggers', (t) ->
+  ex = experiment({
+    name: 'with-triggers'
+    variants:
+      blue:
+        trigger: -> false
+        activate: activate
+      green:
+        trigger: -> true
+        activate: activate
+  })
+  t.plan(2)
+  t.assert(ex.pick_variant() == 'green', 'always picks green variant')
+  t.assert(ex.pick_variant() != 'blue', 'never picks blue variant')
+
 describe 'when all variants have weights (with user_id)', (t) ->
   ex = experiment({
     user_id: 'yuzu'
@@ -146,6 +161,23 @@ describe 'when all variants have weights (with user_id)', (t) ->
   t.plan(2)
   t.assert(ex.pick_variant() == 'blue', 'always picks blue variant')
   ex.user_id = 'gosho'
+  t.assert(ex.pick_variant() == 'red', 'always picks red variant')
+
+describe 'when all variants have triggers (with user_id)', (t) ->
+  changed = { test: true }
+  ex = experiment({
+    user_id: 'yuzu'
+    variants:
+      blue:
+        trigger: -> changed.test
+        activate: activate
+      red:
+        trigger: -> !changed.test
+        activate: activate
+  })
+  t.plan(2)
+  t.assert(ex.pick_variant() == 'blue', 'always picks blue variant')
+  changed.test = false
   t.assert(ex.pick_variant() == 'red', 'always picks red variant')
 
 describe 'when only some variants have weights', (t) ->


### PR DESCRIPTION
This request is to add triggers for variants to control the bucket segments based on data gathered from other services/application data instead of weighted variants. This will allow for A/B testing based off of controlled segments. 